### PR TITLE
GitHub CI: split tests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -30,15 +30,10 @@ jobs:
         build-type: [ debug, release ]
         board: [ sail, ibex-safe-simulator ]
         include:
-          - sonata: false
           - build-type: debug
             build-flags: --debug-loader=y --debug-scheduler=y --debug-allocator=information --allocator-rendering=y -m debug  --print-doubles=y --print-floats=n
           - build-type: release
             build-flags: --debug-loader=n --debug-scheduler=n --debug-allocator=none -m release --stack-usage-check-allocator=y --stack-usage-check-scheduler=y  --print-doubles=n --print-floats=y
-          - board: sonata-simulator
-            build-type: release
-            build-flags: --debug-loader=n --debug-scheduler=n --debug-allocator=none -m release --stack-usage-check-allocator=y --stack-usage-check-scheduler=y  --print-doubles=y --print-floats=y
-            sonata: true
       fail-fast: false
     runs-on: ubuntu-latest
     container:
@@ -58,6 +53,58 @@ jobs:
       run: |
         cd tests
         xmake run
+
+  run-tests-sonata:
+    strategy:
+      matrix:
+        testset-flags:
+          - --most-tests=y --test-allocator=n
+          - --most-tests=n --test-allocator=y
+      fail-fast: false
+    runs-on: ubuntu-latest
+    container:
+      image: ${{ inputs.devcontainer || 'ghcr.io/cheriot-platform/devcontainer:latest' }}
+      options: --user 1001
+    steps:
+    - name: Checkout repository and submodules
+      uses: actions/checkout@v4
+      with:
+        submodules: recursive
+    - name: Build tests
+      run: |
+        cd tests
+        xmake f --board=sonata-simulator --sdk=/cheriot-tools/ --debug-loader=n --debug-scheduler=n --debug-allocator=none -m release --stack-usage-check-allocator=y --stack-usage-check-scheduler=y  --print-doubles=y --print-floats=y ${{ matrix.testset-flags }}
+        xmake
+    - name: Run tests
+      run: |
+        cd tests
+        xmake run
+
+  run-examples:
+    strategy:
+      matrix:
+        build-type: [ debug, release ]
+        board: [ sail, ibex-safe-simulator ]
+        include:
+          - sonata: false
+          - build-type: debug
+            build-flags: --debug-loader=y --debug-scheduler=y --debug-allocator=information --allocator-rendering=y -m debug  --print-doubles=y --print-floats=n
+          - build-type: release
+            build-flags: --debug-loader=n --debug-scheduler=n --debug-allocator=none -m release --stack-usage-check-allocator=y --stack-usage-check-scheduler=y  --print-doubles=n --print-floats=y
+          - board: sonata-simulator
+            build-type: release
+            build-flags: --debug-loader=n --debug-scheduler=n --debug-allocator=none -m release --stack-usage-check-allocator=y --stack-usage-check-scheduler=y  --print-doubles=y --print-floats=y
+            sonata: true
+      fail-fast: false
+    runs-on: ubuntu-latest
+    container:
+      image: ${{ inputs.devcontainer || 'ghcr.io/cheriot-platform/devcontainer:latest' }}
+      options: --user 1001
+    steps:
+    - name: Checkout repository and submodules
+      uses: actions/checkout@v4
+      with:
+        submodules: recursive
     - name: Build examples
       run: |
         set -e
@@ -85,30 +132,11 @@ jobs:
           xmake
         done
 
-  tests-subset:
-    name: Check that we can build and run a proper subset of the test suite
-    runs-on: ubuntu-latest
-    container:
-      image: ghcr.io/cheriot-platform/devcontainer:latest
-      options: --user 1001
-    steps:
-    - name: Checkout repository and submodules
-      uses: actions/checkout@v4
-      with:
-        submodules: recursive
-    - name: Build and run a few tests
-      run: |
-        set -e
-        cd $PWD/tests
-        xmake f --board=sail --sdk=/cheriot-tools/ --most-tests=n --test-preflight=y --test-mmio=y
-        xmake
-        xmake run
-
   test-bigdata:
     name: Check that we can build and run the bigdata tests
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/cheriot-platform/devcontainer:latest
+      image: ${{ inputs.devcontainer || 'ghcr.io/cheriot-platform/devcontainer:latest' }}
       options: --user 1001
     steps:
     - name: Checkout repository and submodules
@@ -127,7 +155,7 @@ jobs:
     name: Check Sonata SRAM-only Hello World
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/cheriot-platform/devcontainer:latest
+      image: ${{ inputs.devcontainer || 'ghcr.io/cheriot-platform/devcontainer:latest' }}
       options: --user 1001
     steps:
     - name: Checkout repository and submodules
@@ -146,7 +174,7 @@ jobs:
     name: Check coding conventions
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/cheriot-platform/devcontainer:latest
+      image: ${{ inputs.devcontainer || 'ghcr.io/cheriot-platform/devcontainer:latest' }}
       options: --user 1001
     steps:
     - name: Checkout repository and submodules
@@ -161,7 +189,8 @@ jobs:
   all-checks:
     needs:
       - run-tests
-      - tests-subset
+      - run-tests-sonata
+      - run-examples
       - test-bigdata
       - sonata-sram-hello
       - check-format

--- a/sdk/include/platform/generic-riscv/platform-timer.hh
+++ b/sdk/include/platform/generic-riscv/platform-timer.hh
@@ -56,26 +56,25 @@ class StandardClint : private utils::NoCopyNoMove
 	}
 
 	/**
-	 * Set the timer up for the next timer interrupt. We need to:
-	 * 1. read the current MTIME,
-	 * 2. add tick amount of cycles to the current time,
-	 * 3. write back the new value to MTIMECMP for the next interrupt.
-	 * Because MTIMECMP is 64-bit and we are a 32-bit CPU, we need to:
-	 * 1. ensure the high 32 bits are stable when we read the low 32 bits
-	 * 2. ensure we write both halves in a way that will not produce
-	 *    spurious interrupts.
+	 * Set the timer comparison for next interrupt to given value.
 	 * Note that CLINT does not need any action to acknowledge the
-	 * interrupt. Writing to any half is enough to clear the interrupt,
-	 * which is also why 2. is important.
+	 * interrupt. Writing to it is enough to clear the interrupt.
+	 * Interrupts must be disabled when calling this function.
 	 */
 	static void setnext(uint64_t nextTime)
 	{
 		/// the high 32 bits of the 64-bit MTIME register
 		volatile uint32_t *pmtimercmphigh = pmtimercmp + 1;
-		uint32_t           curmtimehigh, curmtime, curmtimenew;
 
+		// Attempt to prevent spurious interrupts by writing -1 to mtimeh. The
+		// RISC-V spec actually says to do this by writing to the low 32-bits,
+		// but writing -1 to the high bits also works if we assume that mtimeh
+		// will never reach its maximum value, which it had better not because
+		// the >= comparison makes it impossible to handle wrap around of the
+		// mtime counter anyway. This may be unnecessary given that that we
+		// should have interrupts disabled anyway...
+		*pmtimercmphigh = -1;
 		// Write the new MTIMECMP value, at which the next interrupt fires.
-		*pmtimercmphigh = -1; // Prevent spurious interrupts.
 		*pmtimercmp     = nextTime;
 		*pmtimercmphigh = nextTime >> 32;
 	}
@@ -92,6 +91,13 @@ class StandardClint : private utils::NoCopyNoMove
 		return nextTimer;
 	}
 
+	/**
+	 * Set the timer comparator to a value that should never trigger an
+	 * interrupt.
+	 *
+	 * Note: we rely on the fact that mtimeh should never reach maximum value in
+	 * plausible time-frame.
+	 */
 	static void clear()
 	{
 		volatile uint32_t *pmtimercmphigh = pmtimercmp + 1;


### PR DESCRIPTION
- Move examples and benchmarks to their own matrix

- Split the remaining test matrix into Sonata and everyone else

- Split the Sonata test matrix into "everything but the allocator" and "just the alloator"